### PR TITLE
Moved CacheTimeoutSeconds to appsettings file

### DIFF
--- a/src/content/CloudBoilerplateNet/ProjectOptions.cs
+++ b/src/content/CloudBoilerplateNet/ProjectOptions.cs
@@ -4,5 +4,6 @@
     {
         public string KenticoCloudProjectId { get; set; }
         public string KenticoCloudPreviewApiKey { get; set; }
+        public int CacheTimeoutSeconds { get; set; }
     }
 }

--- a/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
+++ b/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
@@ -33,7 +33,7 @@ namespace CloudBoilerplateNet.Services
 
         #region "Constructors"
 
-        public CachedDeliveryClient(IOptions<ProjectOptions> projectOptions, IMemoryCache memoryCache, int cacheTimeoutSeconds)
+        public CachedDeliveryClient(IOptions<ProjectOptions> projectOptions, IMemoryCache memoryCache)
         {
             if (string.IsNullOrEmpty(projectOptions.Value.KenticoCloudPreviewApiKey))
             {
@@ -47,7 +47,7 @@ namespace CloudBoilerplateNet.Services
                 );
             }
 
-            CacheExpirySeconds = cacheTimeoutSeconds;
+            CacheExpirySeconds = projectOptions.Value.CacheTimeoutSeconds;
             _cache = memoryCache;
         }
 

--- a/src/content/CloudBoilerplateNet/Startup.cs
+++ b/src/content/CloudBoilerplateNet/Startup.cs
@@ -40,7 +40,7 @@ namespace CloudBoilerplateNet
             services.Configure<ProjectOptions>(Configuration);
             services.AddMvc();
 
-            services.AddSingleton<IDeliveryClient>(c => new CachedDeliveryClient(c.GetRequiredService<IOptions<ProjectOptions>>(), c.GetRequiredService<IMemoryCache>(), 5 * 60)
+            services.AddSingleton<IDeliveryClient>(c => new CachedDeliveryClient(c.GetRequiredService<IOptions<ProjectOptions>>(), c.GetRequiredService<IMemoryCache>())
             {
                 CodeFirstModelProvider = { TypeProvider = new CustomTypeProvider() }
             });

--- a/src/content/CloudBoilerplateNet/appsettings.json
+++ b/src/content/CloudBoilerplateNet/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "KenticoCloudProjectId": "975bf280-fd91-488c-994c-2f04416e5ee3",
+  "CacheTimeoutSeconds": "300",
 
   "Logging": {
     "IncludeScopes": false,

--- a/test/CloudBoilerplateNet.Tests/CachedDeliveryClientTests.cs
+++ b/test/CloudBoilerplateNet.Tests/CachedDeliveryClientTests.cs
@@ -14,7 +14,8 @@ namespace CloudBoilerplateNet.Tests
         {
             var projectOptions = Options.Create(new ProjectOptions
             {
-                KenticoCloudProjectId = "975bf280-fd91-488c-994c-2f04416e5ee3"
+                KenticoCloudProjectId = "975bf280-fd91-488c-994c-2f04416e5ee3",
+                CacheTimeoutSeconds = 60
             });
 
             var memoryCacheOptions = Options.Create(new MemoryCacheOptions
@@ -24,7 +25,7 @@ namespace CloudBoilerplateNet.Tests
                 ExpirationScanFrequency = new TimeSpan(0, 0, 5)
             });
 
-            var deliveryClient = new CachedDeliveryClient(projectOptions, new MemoryCache(memoryCacheOptions), 60);
+            var deliveryClient = new CachedDeliveryClient(projectOptions, new MemoryCache(memoryCacheOptions));
 
             var result = deliveryClient.GetItemAsync("home");
 

--- a/test/CloudBoilerplateNet.Tests/Controllers/HomeControllerTests.cs
+++ b/test/CloudBoilerplateNet.Tests/Controllers/HomeControllerTests.cs
@@ -17,7 +17,8 @@ namespace CloudBoilerplateNet.Tests
         {
             var projectOptions = Options.Create(new ProjectOptions
             {
-                KenticoCloudProjectId = "975bf280-fd91-488c-994c-2f04416e5ee3"
+                KenticoCloudProjectId = "975bf280-fd91-488c-994c-2f04416e5ee3",
+                CacheTimeoutSeconds = 60
             });
 
             var memoryCacheOptions = Options.Create(new MemoryCacheOptions
@@ -27,7 +28,7 @@ namespace CloudBoilerplateNet.Tests
                 ExpirationScanFrequency = new TimeSpan(0, 0, 5)
             });
 
-            var deliveryClient = new CachedDeliveryClient(projectOptions, new MemoryCache(memoryCacheOptions), 60);
+            var deliveryClient = new CachedDeliveryClient(projectOptions, new MemoryCache(memoryCacheOptions));
             var controller = new HomeController(deliveryClient);
             var result = Task.Run(() => controller.Index()).Result;
 


### PR DESCRIPTION
Moved the CacheTimeoutSeconds  setting to the appsettings file so that it can be changed on different environments.
(ie. - On production you might want it to 600 seconds and on staging to only 30 seconds or 0)