### PR TITLE
Fix link to quickstart guide on the home page

### DIFF
--- a/src/content/CloudBoilerplateNet/Views/Home/Index.cshtml
+++ b/src/content/CloudBoilerplateNet/Views/Home/Index.cshtml
@@ -16,7 +16,7 @@
 <div class="jumbotron">
     <h1>Let's Get Started</h1>
     <p class="lead">This boilerplate includes a set of features and best practices to kick off your website development with Kentico Cloud smoothly. Take a look into the code how this page works.</p>
-    <p><a class="btn btn-lg btn-success" href="https://github.com/getstarted/cloud-boilerplate-net#quick-start" target="_blank" role="button">Read the Quick Start</a></p>
+    <p><a class="btn btn-lg btn-success" href="https://github.com/Kentico/cloud-boilerplate-net#quick-start" target="_blank" role="button">Read the Quick Start</a></p>
 </div>
 
 <div class="row marketing">


### PR DESCRIPTION
Current link leads to a GetStarted fork of this repository that may not be always up to date.