### PR TITLE
Update example regex

### DIFF
--- a/src/content/CloudBoilerplateNet/IISUrlRewrite.xml
+++ b/src/content/CloudBoilerplateNet/IISUrlRewrite.xml
@@ -20,7 +20,7 @@
     <!-- Example of 301 permanent redirect using Regex patter -->
     <rule name="Regex pattern" stopProcessing="true">
       <match url="^rewrite/(.*)" />
-      <action type="Redirect" url="?rewrittenFrom=$1" appendQueryString="false" redirectType="Permanent" />
+      <action type="Redirect" url="?rewrittenFrom={R:1}" appendQueryString="false" redirectType="Permanent" />
     </rule>
 
     <!-- Example of 301 redirect using transition from old to new url -->


### PR DESCRIPTION
Using [`{R:1}`](https://nicolas.guelpa.me/blog/2015/02/21/rewrite-redirect-iis.html) instead of `$1` for the example pattern fixes the problem of not resolving the matched part of a URL.