### PR TITLE
Ban the cache manager from creating unwanted entries

### DIFF
--- a/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
+++ b/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
@@ -72,7 +72,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemJsonAsync(codename, parameters), 
-                (response) => true, 
+                response => true, 
                 GetContentItemSingleJsonDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -90,7 +90,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemsJsonAsync(parameters), 
-                (response) => response["items"].Count() > 0, 
+                response => response["items"].Count() > 0, 
                 GetContentItemListingJsonDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -133,7 +133,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemAsync(codename, parameters), 
-                (response) => true, 
+                response => true, 
                 GetContentItemSingleDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -154,7 +154,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemAsync<T>(codename, parameters), 
-                (response) => true, 
+                response => true, 
                 GetContentItemSingleDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -183,7 +183,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemsAsync(parameters), 
-                (response) => response.Items.Count > 0, 
+                response => response.Items.Count > 0, 
                 GetContentItemListingDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -208,7 +208,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetItemsAsync<T>(parameters), 
-                (response) => response.Items.Count > 0, 
+                response => response.Items.Count > 0, 
                 GetContentItemListingDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -226,7 +226,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTypeJsonAsync(codename), 
-                (response) => true, 
+                response => true, 
                 GetTypeSingleJsonDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -244,7 +244,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTypesJsonAsync(parameters), 
-                (response) => response["types"].Count() > 0, 
+                response => response["types"].Count() > 0, 
                 GetTypeListingJsonDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -262,7 +262,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTypeAsync(codename), 
-                (response) => true, 
+                response => true, 
                 GetTypeSingleDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -290,7 +290,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTypesAsync(parameters), 
-                (response) => response.Types.Count > 0, 
+                response => response.Types.Count > 0, 
                 GetTypeListingDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -309,7 +309,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetContentElementAsync(contentTypeCodename, contentElementCodename), 
-                (response) => true, 
+                response => true, 
                 GetContentElementDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -327,7 +327,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTaxonomyJsonAsync(codename), 
-                (response) => true, 
+                response => true, 
                 GetTaxonomySingleJsonDependency, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -345,7 +345,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTaxonomiesJsonAsync(parameters), 
-                (response) => response["taxonomies"].Count() > 0, 
+                response => response["taxonomies"].Count() > 0, 
                 GetTaxonomyListingJsonDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -363,7 +363,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTaxonomyAsync(codename), 
-                (response) => true, 
+                response => true, 
                 GetTaxonomySingleDependency, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }
@@ -391,7 +391,7 @@ namespace CloudBoilerplateNet.Services
             return await CacheManager.GetOrCreateAsync(
                 identifierTokens, 
                 () => DeliveryClient.GetTaxonomiesAsync(parameters), 
-                (response) => response.Taxonomies.Count > 0, 
+                response => response.Taxonomies.Count > 0, 
                 GetTaxonomyListingDependencies, 
                 ProjectOptions.CreateCacheEntriesInBackground);
         }

--- a/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
+++ b/src/content/CloudBoilerplateNet/Services/CachedDeliveryClient.cs
@@ -67,7 +67,13 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_SINGLE_JSON_IDENTIFIER, codename };
             identifierTokens.AddRange(parameters);
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemJsonAsync(codename, parameters), GetContentItemSingleJsonDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemJsonAsync(codename, parameters), 
+                (response) => true, 
+                GetContentItemSingleJsonDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -80,7 +86,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_LISTING_JSON_IDENTIFIER };
             identifierTokens.AddRange(parameters);
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemsJsonAsync(parameters), GetContentItemListingJsonDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemsJsonAsync(parameters), 
+                (response) => response["items"].Count() > 0, 
+                GetContentItemListingJsonDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -117,7 +128,13 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_SINGLE_IDENTIFIER, codename };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemAsync(codename, parameters), GetContentItemSingleDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemAsync(codename, parameters), 
+                (response) => true, 
+                GetContentItemSingleDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -132,7 +149,13 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_SINGLE_TYPED_IDENTIFIER, codename };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemAsync<T>(codename, parameters), GetContentItemSingleDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemAsync<T>(codename, parameters), 
+                (response) => true, 
+                GetContentItemSingleDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -156,7 +179,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_LISTING_IDENTIFIER };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemsAsync(parameters), GetContentItemListingDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemsAsync(parameters), 
+                (response) => response.Items.Count > 0, 
+                GetContentItemListingDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -176,7 +204,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ITEM_LISTING_TYPED_IDENTIFIER };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetItemsAsync<T>(parameters), GetContentItemListingDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetItemsAsync<T>(parameters), 
+                (response) => response.Items.Count > 0, 
+                GetContentItemListingDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -188,7 +221,13 @@ namespace CloudBoilerplateNet.Services
         {
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_TYPE_SINGLE_JSON_IDENTIFIER, codename };
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTypeJsonAsync(codename), GetTypeSingleJsonDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTypeJsonAsync(codename), 
+                (response) => true, 
+                GetTypeSingleJsonDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -201,7 +240,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_TYPE_LISTING_JSON_IDENTIFIER };
             identifierTokens.AddRange(parameters);
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTypesJsonAsync(parameters), GetTypeListingJsonDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTypesJsonAsync(parameters), 
+                (response) => response["types"].Count() > 0, 
+                GetTypeListingJsonDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -213,7 +257,13 @@ namespace CloudBoilerplateNet.Services
         {
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_TYPE_SINGLE_IDENTIFIER, codename };
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTypeAsync(codename), GetTypeSingleDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTypeAsync(codename), 
+                (response) => true, 
+                GetTypeSingleDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -236,7 +286,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_TYPE_LISTING_IDENTIFIER };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTypesAsync(parameters), GetTypeListingDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTypesAsync(parameters), 
+                (response) => response.Types.Count > 0, 
+                GetTypeListingDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -249,7 +304,13 @@ namespace CloudBoilerplateNet.Services
         {
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.CONTENT_ELEMENT_IDENTIFIER, contentTypeCodename, contentElementCodename };
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetContentElementAsync(contentTypeCodename, contentElementCodename), GetContentElementDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetContentElementAsync(contentTypeCodename, contentElementCodename), 
+                (response) => true, 
+                GetContentElementDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -261,7 +322,13 @@ namespace CloudBoilerplateNet.Services
         {
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.TAXONOMY_GROUP_SINGLE_JSON_IDENTIFIER, codename };
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTaxonomyJsonAsync(codename), GetTaxonomySingleJsonDependency, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTaxonomyJsonAsync(codename), 
+                (response) => true, 
+                GetTaxonomySingleJsonDependency, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -274,7 +341,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.TAXONOMY_GROUP_LISTING_JSON_IDENTIFIER };
             identifierTokens.AddRange(parameters);
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTaxonomiesJsonAsync(parameters), GetTaxonomyListingJsonDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTaxonomiesJsonAsync(parameters), 
+                (response) => response["taxonomies"].Count() > 0, 
+                GetTaxonomyListingJsonDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -286,7 +358,13 @@ namespace CloudBoilerplateNet.Services
         {
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.TAXONOMY_GROUP_SINGLE_IDENTIFIER, codename };
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTaxonomyAsync(codename), GetTaxonomySingleDependency, ProjectOptions.CreateCacheEntriesInBackground);
+            // The "productionValidator" delegate does not have to do anything since a DeliveryException is thrown instead.
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTaxonomyAsync(codename), 
+                (response) => true, 
+                GetTaxonomySingleDependency, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         /// <summary>
@@ -309,7 +387,12 @@ namespace CloudBoilerplateNet.Services
             var identifierTokens = new List<string> { KenticoCloudCacheHelper.TAXONOMY_GROUP_LISTING_IDENTIFIER };
             identifierTokens.AddRange(KenticoCloudCacheHelper.GetIdentifiersFromParameters(parameters));
 
-            return await CacheManager.GetOrCreateAsync(identifierTokens, () => DeliveryClient.GetTaxonomiesAsync(parameters), GetTaxonomyListingDependencies, ProjectOptions.CreateCacheEntriesInBackground);
+            return await CacheManager.GetOrCreateAsync(
+                identifierTokens, 
+                () => DeliveryClient.GetTaxonomiesAsync(parameters), 
+                (response) => response.Taxonomies.Count > 0, 
+                GetTaxonomyListingDependencies, 
+                ProjectOptions.CreateCacheEntriesInBackground);
         }
 
         #region "Dependency resolvers"

--- a/src/content/CloudBoilerplateNet/Services/ICacheManager.cs
+++ b/src/content/CloudBoilerplateNet/Services/ICacheManager.cs
@@ -19,9 +19,11 @@ namespace CloudBoilerplateNet.Services
         /// <typeparam name="T">Type of the cache entry value.</typeparam>
         /// <param name="identifierTokens">String tokens that form a unique identifier of the entry.</param>
         /// <param name="valueFactory">Method to create the entry.</param>
+        /// <param name="productionValidator">Method to check whether a cache entry is worth creating.</param>
         /// <param name="dependencyListFactory">Method to get a collection of identifiers of entries that the current entry depends upon.</param>
+        /// <param name="createCacheEntriesInBackground">Flag saying if cache entry should be off-loaded to a background thread.</param>
         /// <returns>The cache entry value, either cached or obtained through the <paramref name="valueFactory"/>.</returns>
-        Task<T> GetOrCreateAsync<T>(IEnumerable<string> identifierTokens, Func<Task<T>> valueFactory, Func<T, IEnumerable<IdentifierSet>> dependencyListFactory, bool createCacheEntriesInBackground = true);
+        Task<T> GetOrCreateAsync<T>(IEnumerable<string> identifierTokens, Func<Task<T>> valueFactory, Func<T, bool> productionValidator, Func<T, IEnumerable<IdentifierSet>> dependencyListFactory, bool createCacheEntriesInBackground = true);
 
         /// <summary>
         /// Tries to get a cache entry.

--- a/src/content/CloudBoilerplateNet/Services/ReactiveCacheManager.cs
+++ b/src/content/CloudBoilerplateNet/Services/ReactiveCacheManager.cs
@@ -77,9 +77,11 @@ namespace CloudBoilerplateNet.Services
         /// <typeparam name="T">Type of the cache entry value.</typeparam>
         /// <param name="identifierTokens">String tokens that form a unique identifier of the entry.</param>
         /// <param name="valueFactory">Method to create the entry.</param>
+        /// <param name="productionValidator">Method to check whether a cache entry is worth creating.</param>
         /// <param name="dependencyListFactory">Method to get a collection of identifiers of entries that the current entry depends upon.</param>
+        /// <param name="createCacheEntriesInBackground">Flag saying if cache entry should be off-loaded to a background thread.</param>
         /// <returns>The cache entry value, either cached or obtained through the <paramref name="valueFactory"/>.</returns>
-        public async Task<T> GetOrCreateAsync<T>(IEnumerable<string> identifierTokens, Func<Task<T>> valueFactory, Func<T, IEnumerable<IdentifierSet>> dependencyListFactory, bool createCacheEntriesInBackground = false)
+        public async Task<T> GetOrCreateAsync<T>(IEnumerable<string> identifierTokens, Func<Task<T>> valueFactory, Func<T, bool> productionValidator, Func<T, IEnumerable<IdentifierSet>> dependencyListFactory, bool createCacheEntriesInBackground = false)
         {
             var joinedTokens = StringHelpers.Join(identifierTokens);
             await _semaphoreSlim.WaitAsync();
@@ -92,14 +94,17 @@ namespace CloudBoilerplateNet.Services
                     // If it doesn't exist, get it via valueFactory.
                     T response = await valueFactory();
 
-                    // Create it in a background thread.
-                    if (createCacheEntriesInBackground)
+                    if (productionValidator(response))
                     {
-                        var task = Task.Run(() => CreateEntry(identifierTokens, response, dependencyListFactory));
-                    }
-                    else
-                    {
-                        CreateEntry(identifierTokens, response, dependencyListFactory);
+                        // Create it in a background thread.
+                        if (createCacheEntriesInBackground)
+                        {
+                            var task = Task.Run(() => CreateEntry(identifierTokens, response, dependencyListFactory));
+                        }
+                        else
+                        {
+                            CreateEntry(identifierTokens, response, dependencyListFactory);
+                        }
                     }
 
                     return response;

--- a/test/CloudBoilerplateNet.Tests/Services/ReactiveCacheManagerTests.cs
+++ b/test/CloudBoilerplateNet.Tests/Services/ReactiveCacheManagerTests.cs
@@ -42,7 +42,7 @@ namespace CloudBoilerplateNet.Tests.Services
             List<string> identifiers;
             string value;
             PrepareFixture(out cacheManager, out identifiers, out value);
-            var cacheEntry = await cacheManager.GetOrCreateAsync(identifiers, ValueFactory, ItemFormatDependencyFactory, false);
+            var cacheEntry = await cacheManager.GetOrCreateAsync(identifiers, ValueFactory, (response) => true, ItemFormatDependencyFactory, false);
 
             Assert.Equal(value, cacheManager.MemoryCache.Get<string>(identifiers.First()));
             Assert.NotNull(cacheManager.MemoryCache.Get<CancellationTokenSource>(


### PR DESCRIPTION
The CachedDeliveryClient.Get* methods that return listings may also return empty listings. In these cases creating of cache entries is undesired.

The solution is to introduce a production validator delegate that signals if entry creation is desired or not.