### PR TITLE
Allow not-published items in cache dependency lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,15 @@ To create the web hook, go to Project settings --> Webhooks --> Create new Webho
 
 ![New webhook configuration](https://i.imgur.com/ootVcPZ.png)
 
-**Note**: During local development, you can use the [ngrok](https://ngrok.com/) service to route to your workstation. 
+To get all the benefits of the caching functionality, you should configure the `PreviewApiKey` settings key with the value found in "Project settings" -> "API keys" -> "Delivery Preview API".
+
+![Copy the Preview API key](https://i.imgur.com/lPTyRgZ.png)
+
+This is because the caching functionality always builds a list of dependent KC data from the actual Delivery API response. Without the `PreviewApiKey` settings key, the caching wouldn't know about not-yet-published content items. Publishing of such items would not invalidate cached listing responses and linked items that should now contain the newly-published items. Therefore, you can configure the caching to use the Preview API, simply by having the `DeliveryOptions` -> `PreviewApiKey` key configured in your settings/secrets. You don't have to enable Preview API for your app via `DeliveryOptions` -> `UsePreviewApi`. The app can still run against the production-ready Delivery API. When `UsePreviewApi` is `false` and `PreviewApiKey` is set, then only the caching functionality will use the Preview API to recognize all not-yet-published items upfront.
+
+**Note**: During local development, you can use the [ngrok](https://ngrok.com/) service to route to your workstation. When using IIS Express, you might need to initialize ngrok with a host header:
+
+`ngrok http [port] -host-header="localhost:[port]"`
 
 **Note**: Speed of the Delivery/Preview API service is already tuned up because the service uses a geo-distributed CDN network for most of the types of requests. Therefore, the main advantage of caching in Kentico Cloud applications is not speed but lowering the amount of requests needed (See [pricing](https://kenticocloud.com/pricing) for details).
 

--- a/src/content/CloudBoilerplateNet/Properties/launchSettings.json
+++ b/src/content/CloudBoilerplateNet/Properties/launchSettings.json
@@ -34,6 +34,7 @@
       "launchBrowser": true,
       "launchUrl": "http://localhost:5000",
       "environmentVariables": {
+        "ASPNETCORE_URLS": "http://*:80",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },

--- a/src/content/CloudBoilerplateNet/Services/ICacheManager.cs
+++ b/src/content/CloudBoilerplateNet/Services/ICacheManager.cs
@@ -22,8 +22,15 @@ namespace CloudBoilerplateNet.Services
         /// <param name="skipCacheDelegate">Method to check whether a cache entry should be created (TRUE to skip creation of the entry).</param>
         /// <param name="dependencyListFactory">Method to get a collection of identifiers of entries that the current entry depends upon.</param>
         /// <param name="createCacheEntriesInBackground">Flag saying if cache entry should be off-loaded to a background thread.</param>
+        /// <param name="dependencyListValueFactory">Method to prepare a different input data to build the dependency list.</param>
         /// <returns>The cache entry value, either cached or obtained through the <paramref name="valueFactory"/>.</returns>
-        Task<T> GetOrCreateAsync<T>(IEnumerable<string> identifierTokens, Func<Task<T>> valueFactory, Func<T, bool> skipCacheDelegate, Func<T, IEnumerable<IdentifierSet>> dependencyListFactory, bool createCacheEntriesInBackground = true);
+        Task<T> GetOrCreateAsync<T>(
+            IEnumerable<string> identifierTokens,
+            Func<Task<T>> valueFactory,
+            Func<T, bool> skipCacheDelegate,
+            Func<T, IEnumerable<IdentifierSet>> dependencyListFactory,
+            bool createCacheEntriesInBackground = true,
+            Func<Task<T>> dependencyListValueFactory = null);
 
         /// <summary>
         /// Tries to get a cache entry.

--- a/test/CloudBoilerplateNet.Tests/Services/CachedDeliveryClientTests.cs
+++ b/test/CloudBoilerplateNet.Tests/Services/CachedDeliveryClientTests.cs
@@ -187,6 +187,9 @@ namespace CloudBoilerplateNet.Tests
             for (int i = 0; i < plannedHttpRequests; i++)
             {
                 var response = await cachedClient.GetItemAsync("coffee_beverages_explained", new LanguageParameter("es-ES"));
+
+                // ReactiveCacheManager.CreateEntry needs time to build the cache entry in the background thread. Otherwise actualHttpRequests might be incremented once more.
+                await Task.Delay(500);
             }
 
             Assert.Equal(1, actualHttpRequests.Value);


### PR DESCRIPTION
### Motivation

Fixes #72 

The caching functionality always builds a list of dependent KC data from the actual Delivery API response. Without the Preview API in play, the caching wouldn't know about not-yet-published content items, hence couldn't invalidate cached listing responses and linked items that should be refreshed with the newly-published items.

This update brings the possibility of setting the `DeliveryOptions` -> `PreviewApiKey` key, solely for the purpose of building cache dependency lists. One doesn't have to enable Preview API for the app via `DeliveryOptions` -> `UsePreviewApi`. The app can still run against the production-ready Delivery API. When `UsePreviewApi` is `false` and `PreviewApiKey` is set, then only the caching functionality will use the Preview API to recognize all not-yet-published items upfront.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Run XUnit tests.